### PR TITLE
[DDS-1347] Forwards admin_audit_trail events to Sumo Logic via drupal logs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# linguist configuration for syntax highlighting in github UI.
+*.module linguist-language=PHP
+*.install linguist-language=PHP

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Provides a SumoLogic handler for Monolog.
 
   - [Lagoon logs](https://drupal.org/project/lagoon_logs)
 
+There is also a soft dependency on the following modules
+
+  - [admin audit trail](https://drupal.org/project/admin_audit_trail) - auditable events are sent to the Drupal logs
 
 ## Activation
 

--- a/tide_logs.module
+++ b/tide_logs.module
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Implements hook_admin_audit_trail_log_alter().
+ *
+ * Responds to admin_audit_trail events and forwards it to tide_logs otel collector.
+ */
+function tide_logs_admin_audit_trail_log_alter(&$log) {
+    $channel = sprintf("admin_audit_trail_%s", $log["type"]);
+
+    // Strip out properties that are unnecessary.
+    $filtered_log = $log;
+    unset(
+        $filtered_log["lid"],
+        $filtered_log["type"],
+        $filtered_log["created"],
+        $filtered_log["ip"],
+    );
+
+    // Remove markup from description.
+    $filtered_log["message"] = strip_tags($filtered_log["message"]);
+
+    // Format message as json for simpler parsing in sumo.
+    $message = json_encode($filtered_log, JSON_UNESCAPED_SLASHES);
+    \Drupal::logger($channel)->notice($message);
+}

--- a/tide_logs.module
+++ b/tide_logs.module
@@ -17,10 +17,17 @@ function tide_logs_admin_audit_trail_log_alter(&$log) {
         $filtered_log["ip"],
     );
 
-    // Remove markup from description.
-    $filtered_log["message"] = strip_tags($filtered_log["message"]);
+    // Remove markup from text fields.
+    $filtered_log['description'] = preg_replace( '/[\x{200B}-\x{200D}]/u', '', strip_tags($filtered_log['description']));
+    $filtered_log['ref_char'] = preg_replace( '/[\x{200B}-\x{200D}]/u', '', $filtered_log['ref_char']);
 
-    // Format message as json for simpler parsing in sumo.
-    $message = json_encode($filtered_log, JSON_UNESCAPED_SLASHES);
+    // json not supported in watchdog messages. Using a comma-delimited list
+    // in key:value format.
+    $items = [];
+    foreach ($filtered_log as $key => $value) {
+      $items[] = sprintf("%s:%s", $key, $value);
+    }
+    $message = implode(", ", $items);
+
     \Drupal::logger($channel)->notice($message);
 }

--- a/tide_logs.module
+++ b/tide_logs.module
@@ -5,29 +5,30 @@
  *
  * Responds to admin_audit_trail events and forwards it to tide_logs otel collector.
  */
-function tide_logs_admin_audit_trail_log_alter(&$log) {
-    $channel = sprintf("admin_audit_trail_%s", $log["type"]);
+function tide_logs_admin_audit_trail_log_alter(&$log)
+{
+  $channel = sprintf("admin_audit_trail_%s", $log["type"]);
 
-    // Strip out properties that are unnecessary.
-    $filtered_log = $log;
-    unset(
-        $filtered_log["lid"],
-        $filtered_log["type"],
-        $filtered_log["created"],
-        $filtered_log["ip"],
-    );
+  // Strip out properties that are unnecessary.
+  $filtered_log = $log;
+  unset(
+    $filtered_log["lid"],
+    $filtered_log["type"],
+    $filtered_log["created"],
+    $filtered_log["ip"],
+  );
 
-    // Remove markup from text fields.
-    $filtered_log['description'] = preg_replace( '/[\x{200B}-\x{200D}]/u', '', strip_tags($filtered_log['description']));
-    $filtered_log['ref_char'] = preg_replace( '/[\x{200B}-\x{200D}]/u', '', $filtered_log['ref_char']);
+  // Remove markup from text fields.
+  $filtered_log['description'] = preg_replace('/[\x{200B}-\x{200D}]/u', '', strip_tags($filtered_log['description']));
+  $filtered_log['ref_char'] = preg_replace('/[\x{200B}-\x{200D}]/u', '', $filtered_log['ref_char']);
 
-    // json not supported in watchdog messages. Using a comma-delimited list
-    // in key:value format.
-    $items = [];
-    foreach ($filtered_log as $key => $value) {
-      $items[] = sprintf("%s:%s", $key, $value);
-    }
-    $message = implode(", ", $items);
+  // json not supported in watchdog messages. Using a comma-delimited list
+  // in key:value format.
+  $items = [];
+  foreach ($filtered_log as $key => $value) {
+    $items[] = sprintf("%s:%s", $key, $value);
+  }
+  $message = implode(", ", $items);
 
-    \Drupal::logger($channel)->notice($message);
+  \Drupal::logger($channel)->notice($message);
 }


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/DDS-1347

## Problem

Currently the events logged by admin_audit_trail module remain in the Drupal database, which makes it difficult for us to monitor for unusual behavior, or perform analysis in the case of a security incident.

## Solution

This PR adds a hook which listens to admin_audit_trail's event creation, and then sends the event to the standard Drupal logger.

On environments where tide_logs is enabled, this should result in the events being sent to Sumo.